### PR TITLE
Docs: Spelling Corrections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://github.com/palico-ai/palico-main/assets/32821894/54f35583-41c1-48a3-9565
 
 ## 🛠️ Building your Application
 
-### Build your application with complete flexiblity
+### Build your application with complete flexibility
 With Palico, you have complete control over the implementation details of your LLM application. Building an LLM application with Palico just involves implementing the `Agent` interface. Here's an example:
 ```typescript
 import {


### PR DESCRIPTION
## Description
This pull request addresses spelling errors in the README file of our project.

## Changes Made
- Corrected misspelling of flexiblity to flexibility

## Checklist
- [x] I have reviewed my changes for any additional typos
- [x] The README still renders correctly in markdown
- [x] No code changes were made in this PR

## Additional Information:
This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README file.

Thank you for considering this contribution.